### PR TITLE
fix: urls in robots.txt

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -3,6 +3,5 @@ Sitemap: https://h-projects.github.io/sitemap.xml
 
 
 User-Agent: *
-Disallow: https://h-projects.github.io/404
-Disallow: https://h-projects.github.io/no-g
-
+Disallow: /404/
+Disallow: /no-g/


### PR DESCRIPTION
The current robots.txt throws an error because it has an invalid pattern
![image](https://user-images.githubusercontent.com/53496941/125327286-3b2c3900-e343-11eb-8d3f-be01da044d94.png)